### PR TITLE
Append to variables in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
-CFLAGS=$(shell pkg-config --cflags dvdread)
-LDFLAGS=$(shell pkg-config --libs dvdread)
-OBJECT_FILES=main.o
-TARGETS=main
+CFLAGS += $(shell pkg-config --cflags dvdread)
+LDFLAGS += $(shell pkg-config --libs dvdread)
+OBJECT_FILES = main.o
+TARGETS = main
 
 all: main
 


### PR DESCRIPTION
Append to the build variables in the Makefile to allow adding
build arguments from the command line